### PR TITLE
fix multibyte in asana-read-response

### DIFF
--- a/asana.el
+++ b/asana.el
@@ -155,6 +155,7 @@
   "Read the raw Asana API response from BUF, surfacing errors if any and returning the data payload otherwise."
   (let* ((json-array-type 'list)
          (response (json-read-from-string (with-current-buffer buf
+                                            (set-buffer-multibyte t)
                                             (goto-char url-http-end-of-headers)
                                             (delete-region (point-min) (point))
                                             (buffer-string))))


### PR DESCRIPTION
Fix https://github.com/lmartel/emacs-asana/issues/7

Although multibyte request (asana-create-task) is not fixed.
This is related to emacs bug #23750